### PR TITLE
coins: mark decimals optional and document confidence

### DIFF
--- a/defillama-openapi-free.json
+++ b/defillama-openapi-free.json
@@ -527,9 +527,11 @@
                       "properties": {
                         "ethereum:0xdF574c24545E5FfEcb9a659c229253D4111d87e1": {
                           "type": "object",
+                          "required": ["price", "symbol", "timestamp"],
                           "properties": {
                             "decimals": {
                               "type": "number",
+                              "description": "Token decimals. Omitted for coingecko-native assets (e.g. coingecko:ethereum).",
                               "example": 8
                             },
                             "price": {
@@ -542,6 +544,11 @@
                             },
                             "timestamp": {
                               "type": "number",
+                              "example": 0.99
+                            },
+                            "confidence": {
+                              "type": "number",
+                              "description": "Confidence score between 0 and 1 indicating the reliability of the price.",
                               "example": 0.99
                             }
                           }
@@ -626,9 +633,11 @@
                       "properties": {
                         "ethereum:0xdF574c24545E5FfEcb9a659c229253D4111d87e1": {
                           "type": "object",
+                          "required": ["price", "symbol", "timestamp"],
                           "properties": {
                             "decimals": {
                               "type": "number",
+                              "description": "Token decimals. Omitted for coingecko-native assets (e.g. coingecko:ethereum).",
                               "example": 8
                             },
                             "price": {
@@ -642,6 +651,11 @@
                             "timestamp": {
                               "type": "number",
                               "example": 1648680149
+                            },
+                            "confidence": {
+                              "type": "number",
+                              "description": "Confidence score between 0 and 1 indicating the reliability of the price.",
+                              "example": 0.99
                             }
                           }
                         }
@@ -852,13 +866,16 @@
                       "properties": {
                         "ethereum:0xdF574c24545E5FfEcb9a659c229253D4111d87e1": {
                           "type": "object",
+                          "required": ["confidence", "prices", "symbol"],
                           "properties": {
                             "decimals": {
                               "type": "number",
+                              "description": "Token decimals. Omitted for coingecko-native assets (e.g. coingecko:ethereum).",
                               "example": 8
                             },
                             "confidence": {
                               "type": "number",
+                              "description": "Confidence score between 0 and 1 indicating the reliability of the price.",
                               "example": 0.99
                             },
                             "prices": {

--- a/defillama-openapi-pro.json
+++ b/defillama-openapi-pro.json
@@ -11296,9 +11296,11 @@
                       "properties": {
                         "ethereum:0xdF574c24545E5FfEcb9a659c229253D4111d87e1": {
                           "type": "object",
+                          "required": ["price", "symbol", "timestamp"],
                           "properties": {
                             "decimals": {
                               "type": "number",
+                              "description": "Token decimals. Omitted for coingecko-native assets (e.g. coingecko:ethereum).",
                               "example": 8
                             },
                             "price": {
@@ -11311,6 +11313,11 @@
                             },
                             "timestamp": {
                               "type": "number",
+                              "example": 0.99
+                            },
+                            "confidence": {
+                              "type": "number",
+                              "description": "Confidence score between 0 and 1 indicating the reliability of the price.",
                               "example": 0.99
                             }
                           }
@@ -11390,9 +11397,11 @@
                       "properties": {
                         "ethereum:0xdF574c24545E5FfEcb9a659c229253D4111d87e1": {
                           "type": "object",
+                          "required": ["price", "symbol", "timestamp"],
                           "properties": {
                             "decimals": {
                               "type": "number",
+                              "description": "Token decimals. Omitted for coingecko-native assets (e.g. coingecko:ethereum).",
                               "example": 8
                             },
                             "price": {
@@ -11406,6 +11415,11 @@
                             "timestamp": {
                               "type": "number",
                               "example": 1648680149
+                            },
+                            "confidence": {
+                              "type": "number",
+                              "description": "Confidence score between 0 and 1 indicating the reliability of the price.",
+                              "example": 0.99
                             }
                           }
                         }
@@ -11606,13 +11620,16 @@
                       "properties": {
                         "ethereum:0xdF574c24545E5FfEcb9a659c229253D4111d87e1": {
                           "type": "object",
+                          "required": ["confidence", "prices", "symbol"],
                           "properties": {
                             "decimals": {
                               "type": "number",
+                              "description": "Token decimals. Omitted for coingecko-native assets (e.g. coingecko:ethereum).",
                               "example": 8
                             },
                             "confidence": {
                               "type": "number",
+                              "description": "Confidence score between 0 and 1 indicating the reliability of the price.",
                               "example": 0.99
                             },
                             "prices": {


### PR DESCRIPTION
## Summary
Bring the spec in line with what the coins API actually returns today.

- Mark `decimals` **optional** on `/prices/current`, `/prices/historical`, and `/chart` responses (coingecko-native assets like `coingecko:ethereum` legitimately omit it).
- Add **`confidence`** (number, 0–1) to `/prices/current` and `/prices/historical` response schemas — prod has returned this for a long time but it wasn't documented.
- `/chart` already had `confidence` — added matching description for parity.
- Mirrored all three changes in the pro spec under `/coins/*`.

## Diff shape
`+34 insertions, 0 deletions` across both files. No reformatting — only the new `required` arrays, the new `confidence` property, and descriptions. JSON validates.

## Why now
While building a live spec-compliance test suite against `coins.llama.fi` I found two systematic mismatches that caused test failures:
- Test for `typeof decimals === "number"` failed on coingecko-native batches
- Test for the presence of `confidence` had no schema to compare against

Both are code-behaves-correctly-but-spec-is-wrong cases. This PR fixes the spec side only. Undocumented endpoints in `coins/serverless.yml` (`/mcaps`, `/chains`, `POST /prices`, etc.) are intentionally **not** covered here.

## Test plan
- [ ] Render in Scalar and eyeball the three endpoints' response panels
- [ ] Confirm examples still display as expected
- [ ] Downstream consumer: regenerate TS types from the spec and confirm `confidence` shows up on the right shapes

🤖 Generated with [Claude Code](https://claude.com/claude-code)