### PR TITLE
Update OpenAPI spec links to use GitHub URLs

### DIFF
--- a/llms-pro.txt
+++ b/llms-pro.txt
@@ -68,18 +68,38 @@ Returns: {outflows, oldTokens, currentTokens}
 Get assets of all chains
 Returns: {chain, timestamp}
 
----
-
-## Stablecoins
-
-### GET /stablecoins/stablecoindominance/{chain}
+### GET /api/v2/metrics/tvl/protocol/{protocol}
 **Base URL:** `https://pro-api.llama.fi`
-Get stablecoin dominance per chain along with the info about the larges coin in a chain
+Get aggregate TVL metrics for a protocol
 
 **Parameters:**
-  - `chain` (path, string, required) — chain slug, you can get these from /chains or the chains property on /protocols Example: `Ethereum`
-  - `stablecoin` (query, integer, optional) — stablecoin ID, you can get these from /stablecoins Example: `1`
-Returns: array of {date, totalCirculatingUSD, greatestMcap}
+  - `protocol` (path, string, required) — protocol slug Example: `aave`
+Returns: {id, name, address, symbol, url, referralUrl, description, chain, logo, audits, audit_note, gecko_id, cmcId, category, tags, chains, module, treasury, twitter, audit_links, openSource, forkedFrom, oraclesByChain, parentProtocol, governanceID, github, currentChainTvls, isParentProtocol, mcap, methodology, raises, otherProtocols, hallmarks, stablecoins, misrepresentedTokens, deprecated, rugged, deadUrl, warningBanners, tokenRights, wrongLiquidity, tvlCodePath}
+
+### GET /api/v2/chart/tvl/protocol/{protocol}
+**Base URL:** `https://pro-api.llama.fi`
+Get historical TVL chart for a protocol
+
+**Parameters:**
+  - `protocol` (path, string, required) — protocol slug Example: `uniswap`
+  - `key` (query, string, optional) — Metric to return. Omit for default TVL. Use "all" for the sum of tvl+borrowed+staking+pool2+vesting, or a specific metric like "staking", "borrowed", "vesting", "pool2". (one of: all, staking, borrowed, vesting, pool2) Example: `all`
+
+### GET /api/v2/chart/tvl/protocol/{protocol}/chain-breakdown
+**Base URL:** `https://pro-api.llama.fi`
+Get historical TVL chart for a protocol broken down by chain
+
+**Parameters:**
+  - `protocol` (path, string, required) — protocol slug Example: `euler`
+  - `key` (query, string, optional) — Metric to return. Omit for default TVL. Use "all" for the sum of tvl+borrowed+staking+pool2+vesting, or a specific metric like "staking", "borrowed", "vesting", "pool2". (one of: all, staking, borrowed, vesting, pool2) Example: `borrowed`
+
+### GET /api/v2/chart/tvl/protocol/{protocol}/token-breakdown
+**Base URL:** `https://pro-api.llama.fi`
+Get historical TVL chart for a protocol broken down by token
+
+**Parameters:**
+  - `protocol` (path, string, required) — protocol slug Example: `aave`
+  - `key` (query, string, optional) — Metric to return. Omit for default TVL. Use "all" for the sum of tvl+borrowed+staking+pool2+vesting, or a specific metric like "staking", "borrowed", "vesting", "pool2". (one of: all, staking, borrowed, vesting, pool2)
+  - `currency` (query, string, optional) — Set to "tokens" to return values denominated in raw token amounts instead of USD (one of: usd, token, raw) Example: `usd`
 
 ---
 
@@ -150,6 +170,496 @@ Provides the name of contracts on a determined chain
 
 ---
 
+## Perpetuals & Open Interest
+
+### GET /api/overview/derivatives
+**Base URL:** `https://pro-api.llama.fi`
+Lists all derivatives along summaries of their volumes filtering by chain
+
+**Parameters:**
+  - `excludeTotalDataChart` (query, boolean, required) — true to exclude aggregated chart from response Example: `true`
+  - `excludeTotalDataChartBreakdown` (query, boolean, required) — true to exclude broken down chart from response Example: `true`
+Returns: {totalDataChart, totalDataChartBreakdown, breakdown24h, breakdown30d, chain, allChains, total24h, total48hto24h, total7d, total14dto7d, total60dto30d, total30d, total1y, change_1d, change_7d, change_1m, change_7dover7d, change_30dover30d, total7DaysAgo, total30DaysAgo, totalAllTime, protocols}
+
+### GET /api/summary/derivatives/{protocol}
+**Base URL:** `https://pro-api.llama.fi`
+Volume Details about a specific perp protocol
+
+**Parameters:**
+  - `protocol` (path, string, required) — protocol slug Example: `hyperliquid`
+  - `excludeTotalDataChart` (query, boolean, required) — true to exclude aggregated chart from response Example: `true`
+  - `excludeTotalDataChartBreakdown` (query, boolean, required) — true to exclude broken down chart from response Example: `true`
+Returns: {id, name, url, referralUrl, description, logo, gecko_id, cmcId, chains, twitter, github, symbol, address, childProtocols, linkedProtocols, defillamaId, disabled, displayName, module, category, methodologyURL, methodology, forkedFrom, audits, audit_links, versionKey, governanceID, treasury, parentProtocol, previousNames, latestFetchIsOk, slug, protocolType, total24h, total48hto24h, total7d, totalAllTime, totalDataChart, totalDataChartBreakdown, change_1d}
+
+---
+
+## Treasury
+
+### GET /api/v2/metrics/treasury/protocol/{protocol}
+**Base URL:** `https://pro-api.llama.fi`
+Get aggregate treasury metrics for a protocol
+
+**Parameters:**
+  - `protocol` (path, string, required) — protocol slug Example: `aave`
+Returns: {id, name, address, symbol, url, referralUrl, description, chain, logo, audits, audit_note, gecko_id, cmcId, category, tags, chains, module, treasury, twitter, audit_links, openSource, forkedFrom, oraclesByChain, parentProtocol, governanceID, github, currentChainTvls, isParentProtocol, mcap, methodology, raises, otherProtocols, hallmarks, stablecoins, misrepresentedTokens, deprecated, rugged, deadUrl, warningBanners, tokenRights, wrongLiquidity, tvlCodePath}
+
+### GET /api/v2/chart/treasury/protocol/{protocol}
+**Base URL:** `https://pro-api.llama.fi`
+Get historical treasury chart for a protocol
+
+**Parameters:**
+  - `protocol` (path, string, required) — protocol slug Example: `uniswap`
+  - `key` (query, string, optional) — Token filter. Omit to exclude OwnTokens (default). Use "OwnTokens" to return only the protocol's own tokens, or "all" for the sum of all tokens including OwnTokens. (one of: OwnTokens, all) Example: `all`
+
+### GET /api/v2/chart/treasury/protocol/{protocol}/chain-breakdown
+**Base URL:** `https://pro-api.llama.fi`
+Get historical treasury chart for a protocol broken down by chain
+
+**Parameters:**
+  - `protocol` (path, string, required) — protocol slug Example: `aave`
+  - `key` (query, string, optional) — Token filter. Omit to exclude OwnTokens (default). Use "OwnTokens" to return only the protocol's own tokens, or "all" for the sum of all tokens including OwnTokens. (one of: OwnTokens, all) Example: `OwnTokens`
+
+### GET /api/v2/chart/treasury/protocol/{protocol}/token-breakdown
+**Base URL:** `https://pro-api.llama.fi`
+Get historical treasury chart for a protocol broken down by token
+
+**Parameters:**
+  - `protocol` (path, string, required) — protocol slug Example: `aave`
+  - `key` (query, string, optional) — Token filter. Omit to exclude OwnTokens (default). Use "OwnTokens" to return only the protocol's own tokens, or "all" for the sum of all tokens including OwnTokens. (one of: OwnTokens, all) Example: `OwnTokens`
+  - `currency` (query, string, optional) — Set to "tokens" to return values denominated in raw token amounts instead of USD (one of: usd, token, raw) Example: `usd`
+
+---
+
+## Oracles
+
+### GET /api/v2/metrics/oracle
+**Base URL:** `https://pro-api.llama.fi`
+Get oracle data overview
+Returns: {oracles}
+
+### GET /api/v2/chart/oracle
+**Base URL:** `https://pro-api.llama.fi`
+Get timeseries chart data for all oracles
+
+### GET /api/v2/chart/oracle/chain-breakdown
+**Base URL:** `https://pro-api.llama.fi`
+Get timeseries chart data breakdown by chain
+Returns: array of {timestamp}
+
+### GET /api/v2/chart/oracle/protocol-breakdown
+**Base URL:** `https://pro-api.llama.fi`
+Get timeseries chart data breakdown by protocol
+Returns: array of {timestamp}
+
+### GET /api/v2/chart/oracle/protocol/{protocol}
+**Base URL:** `https://pro-api.llama.fi`
+Get timeseries chart data by protocol/oracle
+
+**Parameters:**
+  - `protocol` (path, string, required) — oracle/protocol name Example: `Chainlink`
+
+### GET /api/v2/chart/oracle/protocol/{protocol}/chain-breakdown
+**Base URL:** `https://pro-api.llama.fi`
+Get chain breakdown timeseries chart data by protocol/oracle
+
+**Parameters:**
+  - `protocol` (path, string, required) — oracle/protocol name Example: `Chainlink`
+Returns: array of {timestamp}
+
+### GET /api/v2/chart/oracle/chain/{chain}
+**Base URL:** `https://pro-api.llama.fi`
+Get timeseries chart data by chain
+
+**Parameters:**
+  - `chain` (path, string, required) — chain name Example: `Ethereum`
+
+### GET /api/v2/chart/oracle/chain/{chain}/protocol-breakdown
+**Base URL:** `https://pro-api.llama.fi`
+Get protocol breakdown timeseries chart data by chain
+
+**Parameters:**
+  - `chain` (path, string, required) — chain name Example: `Ethereum`
+Returns: array of {timestamp}
+
+---
+
+## Forks
+
+### GET /api/v2/metrics/fork
+**Base URL:** `https://pro-api.llama.fi`
+Get fork data overview
+Returns: object
+
+### GET /api/v2/chart/fork/protocol-breakdown
+**Base URL:** `https://pro-api.llama.fi`
+Get timeseries chart data breakdown by protocol
+Returns: array of {timestamp}
+
+### GET /api/v2/chart/fork/protocol/{protocol}
+**Base URL:** `https://pro-api.llama.fi`
+Get timeseries chart data by protocol
+
+**Parameters:**
+  - `protocol` (path, string, required) — protocol slug Example: `aave-v3`
+
+---
+
+## Dimensions
+
+### GET /api/v2/metrics/{metric}
+**Base URL:** `https://pro-api.llama.fi`
+Get dimension data overview
+
+**Parameters:**
+  - `metric` (path, string, required) — The dimension metric type (one of: fees, dexs, derivatives, options, aggregators, bridge-aggregators, open-interest, normalized-volume) Example: `fees`
+  - `dataType` (query, string, optional) — Metric-specific data type to return. Supported values per metric:
+- **fees**: dailyFees (default), dailyRevenue, dailySupplySideRevenue, dailyHoldersRevenue, dailyProtocolRevenue
+- **dexs**: dailyVolume (default), dailyNotionalVolume
+- **derivatives**: dailyVolume (default), dailyNotionalVolume
+- **options**: dailyNotionalVolume (default), dailyPremiumVolume
+- **aggregators**: dailyVolume (default)
+- **bridge-aggregators**: dailyBridgeVolume (default)
+- **open-interest**: openInterestAtEnd (default), shortOpenInterestAtEnd, longOpenInterestAtEnd
+- **normalized-volume**: dailyNormalizedVolume (default), dailyActiveLiquidity Example: `dailyFees`
+Returns: {allChains, total24h, total48hto24h, total7d, total14dto7d, total60dto30d, total30d, total1y, change_1d, change_7d, change_1m, change_7dover7d, change_30dover30d}
+
+### GET /api/v2/chart/{metric}
+**Base URL:** `https://pro-api.llama.fi`
+Get historical timeseries chart data
+
+**Parameters:**
+  - `metric` (path, string, required) — The dimension metric type (one of: fees, dexs, derivatives, options, aggregators, bridge-aggregators, open-interest, normalized-volume) Example: `fees`
+  - `dataType` (query, string, optional) — Metric-specific data type to return. Supported values per metric:
+- **fees**: dailyFees (default), dailyRevenue, dailySupplySideRevenue, dailyHoldersRevenue, dailyProtocolRevenue
+- **dexs**: dailyVolume (default), dailyNotionalVolume
+- **derivatives**: dailyVolume (default), dailyNotionalVolume
+- **options**: dailyNotionalVolume (default), dailyPremiumVolume
+- **aggregators**: dailyVolume (default)
+- **bridge-aggregators**: dailyBridgeVolume (default)
+- **open-interest**: openInterestAtEnd (default), shortOpenInterestAtEnd, longOpenInterestAtEnd
+- **normalized-volume**: dailyNormalizedVolume (default), dailyActiveLiquidity Example: `dailyFees`
+
+### GET /api/v2/chart/{metric}/chain-breakdown
+**Base URL:** `https://pro-api.llama.fi`
+Get historical timeseries chart data breakdown by chain
+
+**Parameters:**
+  - `metric` (path, string, required) — The dimension metric type (one of: fees, dexs, derivatives, options, aggregators, bridge-aggregators, open-interest, normalized-volume) Example: `fees`
+  - `dataType` (query, string, optional) — Metric-specific data type to return. Supported values per metric:
+- **fees**: dailyFees (default), dailyRevenue, dailySupplySideRevenue, dailyHoldersRevenue, dailyProtocolRevenue
+- **dexs**: dailyVolume (default), dailyNotionalVolume
+- **derivatives**: dailyVolume (default), dailyNotionalVolume
+- **options**: dailyNotionalVolume (default), dailyPremiumVolume
+- **aggregators**: dailyVolume (default)
+- **bridge-aggregators**: dailyBridgeVolume (default)
+- **open-interest**: openInterestAtEnd (default), shortOpenInterestAtEnd, longOpenInterestAtEnd
+- **normalized-volume**: dailyNormalizedVolume (default), dailyActiveLiquidity Example: `dailyFees`
+
+### GET /api/v2/chart/{metric}/protocol-breakdown
+**Base URL:** `https://pro-api.llama.fi`
+Get historical timeseries chart data breakdown by protocol
+
+**Parameters:**
+  - `metric` (path, string, required) — The dimension metric type (one of: fees, dexs, derivatives, options, aggregators, bridge-aggregators, open-interest, normalized-volume) Example: `fees`
+  - `dataType` (query, string, optional) — Metric-specific data type to return. Supported values per metric:
+- **fees**: dailyFees (default), dailyRevenue, dailySupplySideRevenue, dailyHoldersRevenue, dailyProtocolRevenue
+- **dexs**: dailyVolume (default), dailyNotionalVolume
+- **derivatives**: dailyVolume (default), dailyNotionalVolume
+- **options**: dailyNotionalVolume (default), dailyPremiumVolume
+- **aggregators**: dailyVolume (default)
+- **bridge-aggregators**: dailyBridgeVolume (default)
+- **open-interest**: openInterestAtEnd (default), shortOpenInterestAtEnd, longOpenInterestAtEnd
+- **normalized-volume**: dailyNormalizedVolume (default), dailyActiveLiquidity Example: `dailyFees`
+
+### GET /api/v2/metrics/{metric}/chain/{chain}
+**Base URL:** `https://pro-api.llama.fi`
+Get chain dimension data overview
+
+**Parameters:**
+  - `metric` (path, string, required) — The dimension metric type (one of: fees, dexs, derivatives, options, aggregators, bridge-aggregators, open-interest, normalized-volume) Example: `fees`
+  - `chain` (path, string, required) — chain name Example: `Ethereum`
+  - `dataType` (query, string, optional) — Metric-specific data type to return. Supported values per metric:
+- **fees**: dailyFees (default), dailyRevenue, dailySupplySideRevenue, dailyHoldersRevenue, dailyProtocolRevenue
+- **dexs**: dailyVolume (default), dailyNotionalVolume
+- **derivatives**: dailyVolume (default), dailyNotionalVolume
+- **options**: dailyNotionalVolume (default), dailyPremiumVolume
+- **aggregators**: dailyVolume (default)
+- **bridge-aggregators**: dailyBridgeVolume (default)
+- **open-interest**: openInterestAtEnd (default), shortOpenInterestAtEnd, longOpenInterestAtEnd
+- **normalized-volume**: dailyNormalizedVolume (default), dailyActiveLiquidity Example: `dailyFees`
+Returns: {allChains, total24h, total48hto24h, total7d, total14dto7d, total60dto30d, total30d, total1y, change_1d, change_7d, change_1m, change_7dover7d, change_30dover30d, chain}
+
+### GET /api/v2/chart/{metric}/chain/{chain}
+**Base URL:** `https://pro-api.llama.fi`
+Get chain historical timeseries chart data
+
+**Parameters:**
+  - `metric` (path, string, required) — The dimension metric type (one of: fees, dexs, derivatives, options, aggregators, bridge-aggregators, open-interest, normalized-volume) Example: `fees`
+  - `chain` (path, string, required) — chain name Example: `Ethereum`
+  - `dataType` (query, string, optional) — Metric-specific data type to return. Supported values per metric:
+- **fees**: dailyFees (default), dailyRevenue, dailySupplySideRevenue, dailyHoldersRevenue, dailyProtocolRevenue
+- **dexs**: dailyVolume (default), dailyNotionalVolume
+- **derivatives**: dailyVolume (default), dailyNotionalVolume
+- **options**: dailyNotionalVolume (default), dailyPremiumVolume
+- **aggregators**: dailyVolume (default)
+- **bridge-aggregators**: dailyBridgeVolume (default)
+- **open-interest**: openInterestAtEnd (default), shortOpenInterestAtEnd, longOpenInterestAtEnd
+- **normalized-volume**: dailyNormalizedVolume (default), dailyActiveLiquidity Example: `dailyFees`
+
+### GET /api/v2/chart/{metric}/chain/{chain}/protocol-breakdown
+**Base URL:** `https://pro-api.llama.fi`
+Get chain timeseries chart data breakdown by protocol
+
+**Parameters:**
+  - `metric` (path, string, required) — The dimension metric type (one of: fees, dexs, derivatives, options, aggregators, bridge-aggregators, open-interest, normalized-volume) Example: `fees`
+  - `chain` (path, string, required) — chain name Example: `Ethereum`
+  - `dataType` (query, string, optional) — Metric-specific data type to return. Supported values per metric:
+- **fees**: dailyFees (default), dailyRevenue, dailySupplySideRevenue, dailyHoldersRevenue, dailyProtocolRevenue
+- **dexs**: dailyVolume (default), dailyNotionalVolume
+- **derivatives**: dailyVolume (default), dailyNotionalVolume
+- **options**: dailyNotionalVolume (default), dailyPremiumVolume
+- **aggregators**: dailyVolume (default)
+- **bridge-aggregators**: dailyBridgeVolume (default)
+- **open-interest**: openInterestAtEnd (default), shortOpenInterestAtEnd, longOpenInterestAtEnd
+- **normalized-volume**: dailyNormalizedVolume (default), dailyActiveLiquidity Example: `dailyFees`
+
+### GET /api/v2/metrics/{metric}/protocol/{protocol}
+**Base URL:** `https://pro-api.llama.fi`
+Get protocol dimension data overview
+
+**Parameters:**
+  - `metric` (path, string, required) — The dimension metric type (one of: fees, dexs, derivatives, options, aggregators, bridge-aggregators, open-interest, normalized-volume) Example: `fees`
+  - `protocol` (path, string, required) — protocol slug (slugified protocol name) Example: `aave`
+  - `dataType` (query, string, optional) — Metric-specific data type to return. Supported values per metric:
+- **fees**: dailyFees (default), dailyRevenue, dailySupplySideRevenue, dailyHoldersRevenue, dailyProtocolRevenue
+- **dexs**: dailyVolume (default), dailyNotionalVolume
+- **derivatives**: dailyVolume (default), dailyNotionalVolume
+- **options**: dailyNotionalVolume (default), dailyPremiumVolume
+- **aggregators**: dailyVolume (default)
+- **bridge-aggregators**: dailyBridgeVolume (default)
+- **open-interest**: openInterestAtEnd (default), shortOpenInterestAtEnd, longOpenInterestAtEnd
+- **normalized-volume**: dailyNormalizedVolume (default), dailyActiveLiquidity Example: `dailyFees`
+Returns: {id, name, url, description, logo, chains, gecko_id, cmcId, symbol, twitter, github, treasury, governanceID, wrongLiquidity, stablecoins, total24h, total48hto24h, total7d, total30d, total1y, change_1d, change_7d, change_1m}
+
+### GET /api/v2/chart/{metric}/protocol/{protocol}
+**Base URL:** `https://pro-api.llama.fi`
+Get protocol historical timeseries chart data
+
+**Parameters:**
+  - `metric` (path, string, required) — The dimension metric type (one of: fees, dexs, derivatives, options, aggregators, bridge-aggregators, open-interest, normalized-volume) Example: `fees`
+  - `protocol` (path, string, required) — protocol slug (slugified protocol name) Example: `aave`
+  - `dataType` (query, string, optional) — Metric-specific data type to return. Supported values per metric:
+- **fees**: dailyFees (default), dailyRevenue, dailySupplySideRevenue, dailyHoldersRevenue, dailyProtocolRevenue
+- **dexs**: dailyVolume (default), dailyNotionalVolume
+- **derivatives**: dailyVolume (default), dailyNotionalVolume
+- **options**: dailyNotionalVolume (default), dailyPremiumVolume
+- **aggregators**: dailyVolume (default)
+- **bridge-aggregators**: dailyBridgeVolume (default)
+- **open-interest**: openInterestAtEnd (default), shortOpenInterestAtEnd, longOpenInterestAtEnd
+- **normalized-volume**: dailyNormalizedVolume (default), dailyActiveLiquidity Example: `dailyFees`
+
+### GET /api/v2/chart/{metric}/protocol/{protocol}/chain-breakdown
+**Base URL:** `https://pro-api.llama.fi`
+Get protocol timeseries chart data breakdown by chain
+
+**Parameters:**
+  - `metric` (path, string, required) — The dimension metric type (one of: fees, dexs, derivatives, options, aggregators, bridge-aggregators, open-interest, normalized-volume) Example: `fees`
+  - `protocol` (path, string, required) — protocol slug (slugified protocol name) Example: `aave`
+  - `dataType` (query, string, optional) — Metric-specific data type to return. Supported values per metric:
+- **fees**: dailyFees (default), dailyRevenue, dailySupplySideRevenue, dailyHoldersRevenue, dailyProtocolRevenue
+- **dexs**: dailyVolume (default), dailyNotionalVolume
+- **derivatives**: dailyVolume (default), dailyNotionalVolume
+- **options**: dailyNotionalVolume (default), dailyPremiumVolume
+- **aggregators**: dailyVolume (default)
+- **bridge-aggregators**: dailyBridgeVolume (default)
+- **open-interest**: openInterestAtEnd (default), shortOpenInterestAtEnd, longOpenInterestAtEnd
+- **normalized-volume**: dailyNormalizedVolume (default), dailyActiveLiquidity Example: `dailyFees`
+
+### GET /api/v2/chart/{metric}/protocol/{protocol}/version-breakdown
+**Base URL:** `https://pro-api.llama.fi`
+Get protocol timeseries chart data breakdown by version
+
+**Parameters:**
+  - `metric` (path, string, required) — The dimension metric type (one of: fees, dexs, derivatives, options, aggregators, bridge-aggregators, open-interest, normalized-volume) Example: `fees`
+  - `protocol` (path, string, required) — protocol slug (slugified protocol name) Example: `aave`
+  - `dataType` (query, string, optional) — Metric-specific data type to return. Supported values per metric:
+- **fees**: dailyFees (default), dailyRevenue, dailySupplySideRevenue, dailyHoldersRevenue, dailyProtocolRevenue
+- **dexs**: dailyVolume (default), dailyNotionalVolume
+- **derivatives**: dailyVolume (default), dailyNotionalVolume
+- **options**: dailyNotionalVolume (default), dailyPremiumVolume
+- **aggregators**: dailyVolume (default)
+- **bridge-aggregators**: dailyBridgeVolume (default)
+- **open-interest**: openInterestAtEnd (default), shortOpenInterestAtEnd, longOpenInterestAtEnd
+- **normalized-volume**: dailyNormalizedVolume (default), dailyActiveLiquidity Example: `dailyFees`
+
+### GET /api/v2/chart/{metric}/protocol/{protocol}/label-breakdown
+**Base URL:** `https://pro-api.llama.fi`
+Get protocol timeseries chart data breakdown by label
+
+**Parameters:**
+  - `metric` (path, string, required) — The dimension metric type (one of: fees, dexs, derivatives, options, aggregators, bridge-aggregators, open-interest, normalized-volume) Example: `fees`
+  - `protocol` (path, string, required) — protocol slug (slugified protocol name) Example: `aave`
+  - `dataType` (query, string, optional) — Metric-specific data type to return. Supported values per metric:
+- **fees**: dailyFees (default), dailyRevenue, dailySupplySideRevenue, dailyHoldersRevenue, dailyProtocolRevenue
+- **dexs**: dailyVolume (default), dailyNotionalVolume
+- **derivatives**: dailyVolume (default), dailyNotionalVolume
+- **options**: dailyNotionalVolume (default), dailyPremiumVolume
+- **aggregators**: dailyVolume (default)
+- **bridge-aggregators**: dailyBridgeVolume (default)
+- **open-interest**: openInterestAtEnd (default), shortOpenInterestAtEnd, longOpenInterestAtEnd
+- **normalized-volume**: dailyNormalizedVolume (default), dailyActiveLiquidity Example: `dailyFees`
+
+### GET /api/v2/metrics/{metric}/category/{category}
+**Base URL:** `https://pro-api.llama.fi`
+Get category dimension data overview
+
+**Parameters:**
+  - `metric` (path, string, required) — The dimension metric type (one of: fees, dexs, derivatives, options, aggregators, bridge-aggregators, open-interest, normalized-volume) Example: `fees`
+  - `category` (path, string, required) — category slug (slugified category name, e.g. 'dexs', 'prediction-market', 'options') Example: `dexs`
+  - `dataType` (query, string, optional) — Metric-specific data type to return. Supported values per metric:
+- **fees**: dailyFees (default), dailyRevenue, dailySupplySideRevenue, dailyHoldersRevenue, dailyProtocolRevenue
+- **dexs**: dailyVolume (default), dailyNotionalVolume
+- **derivatives**: dailyVolume (default), dailyNotionalVolume
+- **options**: dailyNotionalVolume (default), dailyPremiumVolume
+- **aggregators**: dailyVolume (default)
+- **bridge-aggregators**: dailyBridgeVolume (default)
+- **open-interest**: openInterestAtEnd (default), shortOpenInterestAtEnd, longOpenInterestAtEnd
+- **normalized-volume**: dailyNormalizedVolume (default), dailyActiveLiquidity Example: `dailyFees`
+Returns: {allChains, total24h, total48hto24h, total7d, total14dto7d, total60dto30d, total30d, total1y, change_1d, change_7d, change_1m, change_7dover7d, change_30dover30d, category, allCategories}
+
+### GET /api/v2/chart/{metric}/category/{category}
+**Base URL:** `https://pro-api.llama.fi`
+Get category historical timeseries chart data
+
+**Parameters:**
+  - `metric` (path, string, required) — The dimension metric type (one of: fees, dexs, derivatives, options, aggregators, bridge-aggregators, open-interest, normalized-volume) Example: `fees`
+  - `category` (path, string, required) — category slug (slugified category name, e.g. 'dexs', 'prediction-market', 'options') Example: `dexs`
+  - `dataType` (query, string, optional) — Metric-specific data type to return. Supported values per metric:
+- **fees**: dailyFees (default), dailyRevenue, dailySupplySideRevenue, dailyHoldersRevenue, dailyProtocolRevenue
+- **dexs**: dailyVolume (default), dailyNotionalVolume
+- **derivatives**: dailyVolume (default), dailyNotionalVolume
+- **options**: dailyNotionalVolume (default), dailyPremiumVolume
+- **aggregators**: dailyVolume (default)
+- **bridge-aggregators**: dailyBridgeVolume (default)
+- **open-interest**: openInterestAtEnd (default), shortOpenInterestAtEnd, longOpenInterestAtEnd
+- **normalized-volume**: dailyNormalizedVolume (default), dailyActiveLiquidity Example: `dailyFees`
+
+### GET /api/v2/chart/{metric}/category/{category}/chain-breakdown
+**Base URL:** `https://pro-api.llama.fi`
+Get category timeseries chart data breakdown by chain
+
+**Parameters:**
+  - `metric` (path, string, required) — The dimension metric type (one of: fees, dexs, derivatives, options, aggregators, bridge-aggregators, open-interest, normalized-volume) Example: `fees`
+  - `category` (path, string, required) — category slug (slugified category name, e.g. 'dexs', 'prediction-market', 'options') Example: `dexs`
+  - `dataType` (query, string, optional) — Metric-specific data type to return. Supported values per metric:
+- **fees**: dailyFees (default), dailyRevenue, dailySupplySideRevenue, dailyHoldersRevenue, dailyProtocolRevenue
+- **dexs**: dailyVolume (default), dailyNotionalVolume
+- **derivatives**: dailyVolume (default), dailyNotionalVolume
+- **options**: dailyNotionalVolume (default), dailyPremiumVolume
+- **aggregators**: dailyVolume (default)
+- **bridge-aggregators**: dailyBridgeVolume (default)
+- **open-interest**: openInterestAtEnd (default), shortOpenInterestAtEnd, longOpenInterestAtEnd
+- **normalized-volume**: dailyNormalizedVolume (default), dailyActiveLiquidity Example: `dailyFees`
+
+### GET /api/v2/chart/{metric}/category/{category}/protocol-breakdown
+**Base URL:** `https://pro-api.llama.fi`
+Get category timeseries chart data breakdown by protocol
+
+**Parameters:**
+  - `metric` (path, string, required) — The dimension metric type (one of: fees, dexs, derivatives, options, aggregators, bridge-aggregators, open-interest, normalized-volume) Example: `fees`
+  - `category` (path, string, required) — category slug (slugified category name, e.g. 'dexs', 'prediction-market', 'options') Example: `dexs`
+  - `dataType` (query, string, optional) — Metric-specific data type to return. Supported values per metric:
+- **fees**: dailyFees (default), dailyRevenue, dailySupplySideRevenue, dailyHoldersRevenue, dailyProtocolRevenue
+- **dexs**: dailyVolume (default), dailyNotionalVolume
+- **derivatives**: dailyVolume (default), dailyNotionalVolume
+- **options**: dailyNotionalVolume (default), dailyPremiumVolume
+- **aggregators**: dailyVolume (default)
+- **bridge-aggregators**: dailyBridgeVolume (default)
+- **open-interest**: openInterestAtEnd (default), shortOpenInterestAtEnd, longOpenInterestAtEnd
+- **normalized-volume**: dailyNormalizedVolume (default), dailyActiveLiquidity Example: `dailyFees`
+
+### GET /api/v2/metrics/{metric}/category/{category}/chain/{chain}
+**Base URL:** `https://pro-api.llama.fi`
+Get category chain dimension data overview
+
+**Parameters:**
+  - `metric` (path, string, required) — The dimension metric type (one of: fees, dexs, derivatives, options, aggregators, bridge-aggregators, open-interest, normalized-volume) Example: `fees`
+  - `category` (path, string, required) — category slug (slugified category name, e.g. 'dexs', 'prediction-market', 'options') Example: `dexs`
+  - `chain` (path, string, required) — chain name Example: `Ethereum`
+  - `dataType` (query, string, optional) — Metric-specific data type to return. Supported values per metric:
+- **fees**: dailyFees (default), dailyRevenue, dailySupplySideRevenue, dailyHoldersRevenue, dailyProtocolRevenue
+- **dexs**: dailyVolume (default), dailyNotionalVolume
+- **derivatives**: dailyVolume (default), dailyNotionalVolume
+- **options**: dailyNotionalVolume (default), dailyPremiumVolume
+- **aggregators**: dailyVolume (default)
+- **bridge-aggregators**: dailyBridgeVolume (default)
+- **open-interest**: openInterestAtEnd (default), shortOpenInterestAtEnd, longOpenInterestAtEnd
+- **normalized-volume**: dailyNormalizedVolume (default), dailyActiveLiquidity Example: `dailyFees`
+Returns: {allChains, total24h, total48hto24h, total7d, total14dto7d, total60dto30d, total30d, total1y, change_1d, change_7d, change_1m, change_7dover7d, change_30dover30d, category, allCategories, chain}
+
+### GET /api/v2/chart/{metric}/category/{category}/chain/{chain}
+**Base URL:** `https://pro-api.llama.fi`
+Get category chain historical timeseries chart data
+
+**Parameters:**
+  - `metric` (path, string, required) — The dimension metric type (one of: fees, dexs, derivatives, options, aggregators, bridge-aggregators, open-interest, normalized-volume) Example: `fees`
+  - `category` (path, string, required) — category slug (slugified category name, e.g. 'dexs', 'prediction-market', 'options') Example: `dexs`
+  - `chain` (path, string, required) — chain name Example: `Ethereum`
+  - `dataType` (query, string, optional) — Metric-specific data type to return. Supported values per metric:
+- **fees**: dailyFees (default), dailyRevenue, dailySupplySideRevenue, dailyHoldersRevenue, dailyProtocolRevenue
+- **dexs**: dailyVolume (default), dailyNotionalVolume
+- **derivatives**: dailyVolume (default), dailyNotionalVolume
+- **options**: dailyNotionalVolume (default), dailyPremiumVolume
+- **aggregators**: dailyVolume (default)
+- **bridge-aggregators**: dailyBridgeVolume (default)
+- **open-interest**: openInterestAtEnd (default), shortOpenInterestAtEnd, longOpenInterestAtEnd
+- **normalized-volume**: dailyNormalizedVolume (default), dailyActiveLiquidity Example: `dailyFees`
+
+### GET /api/v2/chart/{metric}/category/{category}/chain/{chain}/protocol-breakdown
+**Base URL:** `https://pro-api.llama.fi`
+Get category chain timeseries chart data breakdown by protocol
+
+**Parameters:**
+  - `metric` (path, string, required) — The dimension metric type (one of: fees, dexs, derivatives, options, aggregators, bridge-aggregators, open-interest, normalized-volume) Example: `fees`
+  - `category` (path, string, required) — category slug (slugified category name, e.g. 'dexs', 'prediction-market', 'options') Example: `dexs`
+  - `chain` (path, string, required) — chain name Example: `Ethereum`
+  - `dataType` (query, string, optional) — Metric-specific data type to return. Supported values per metric:
+- **fees**: dailyFees (default), dailyRevenue, dailySupplySideRevenue, dailyHoldersRevenue, dailyProtocolRevenue
+- **dexs**: dailyVolume (default), dailyNotionalVolume
+- **derivatives**: dailyVolume (default), dailyNotionalVolume
+- **options**: dailyNotionalVolume (default), dailyPremiumVolume
+- **aggregators**: dailyVolume (default)
+- **bridge-aggregators**: dailyBridgeVolume (default)
+- **open-interest**: openInterestAtEnd (default), shortOpenInterestAtEnd, longOpenInterestAtEnd
+- **normalized-volume**: dailyNormalizedVolume (default), dailyActiveLiquidity Example: `dailyFees`
+
+---
+
+## Financial Statements
+
+### GET /api/v2/metrics/financial-statement/protocol/{protocol}
+**Base URL:** `https://pro-api.llama.fi`
+Get protocol income statement report
+
+**Parameters:**
+  - `protocol` (path, string, required) — protocol slug (e.g. aave-v3, hyperliquid) Example: `aave-v3`
+Returns: {id, name, address, symbol, url, description, chain, logo, audits, audit_links, category, chains, oraclesBreakdown, module, twitter, github, listedAt, parentProtocol, dimensions, methodology, breakdownMethodology, methodologyURL, tvlCodePath, hallmarks, linkedProtocols, childProtocols, hasLabelBreakdown, defillamaId, displayName, slug, protocolType, aggregates}
+
+---
+
+## Stablecoins
+
+### GET /stablecoins/stablecoindominance/{chain}
+**Base URL:** `https://pro-api.llama.fi`
+Get stablecoin dominance per chain along with the info about the larges coin in a chain
+
+**Parameters:**
+  - `chain` (path, string, required) — chain slug, you can get these from /chains or the chains property on /protocols Example: `Ethereum`
+  - `stablecoin` (query, integer, optional) — stablecoin ID, you can get these from /stablecoins Example: `1`
+Returns: array of {date, totalCirculatingUSD, greatestMcap}
+
+---
+
 ## Yields & APY
 
 ### GET /yields/poolsOld
@@ -205,29 +715,6 @@ Get chart of narratives based on category performance (with individual coins wei
 **Parameters:**
   - `period` (path, string, required) — One of ['7', '30', 'ytd', '365'] Example: `30`
 Returns: array of {date, Analytics, Artificial Intelligence (AI), Bitcoin, Bridge Governance Tokens, Centralized Exchange (CEX) Token, Data Availability, Decentralized Finance (DeFi), Decentralized Identifier (DID), DePIN, Ethereum, Gaming (GameFi), Liquid Staking Governance Tokens, Meme, NFT Marketplace, Oracle, PolitiFi, Prediction Markets, Real World Assets (RWA), Rollup, Smart Contract Platform, SocialFi, Solana}
-
----
-
-## Perpetuals & Open Interest
-
-### GET /api/overview/derivatives
-**Base URL:** `https://pro-api.llama.fi`
-Lists all derivatives along summaries of their volumes filtering by chain
-
-**Parameters:**
-  - `excludeTotalDataChart` (query, boolean, required) — true to exclude aggregated chart from response Example: `true`
-  - `excludeTotalDataChartBreakdown` (query, boolean, required) — true to exclude broken down chart from response Example: `true`
-Returns: {totalDataChart, totalDataChartBreakdown, breakdown24h, breakdown30d, chain, allChains, total24h, total48hto24h, total7d, total14dto7d, total60dto30d, total30d, total1y, change_1d, change_7d, change_1m, change_7dover7d, change_30dover30d, total7DaysAgo, total30DaysAgo, totalAllTime, protocols}
-
-### GET /api/summary/derivatives/{protocol}
-**Base URL:** `https://pro-api.llama.fi`
-Volume Details about a specific perp protocol
-
-**Parameters:**
-  - `protocol` (path, string, required) — protocol slug Example: `hyperliquid`
-  - `excludeTotalDataChart` (query, boolean, required) — true to exclude aggregated chart from response Example: `true`
-  - `excludeTotalDataChartBreakdown` (query, boolean, required) — true to exclude broken down chart from response Example: `true`
-Returns: {id, name, url, referralUrl, description, logo, gecko_id, cmcId, chains, twitter, github, symbol, address, childProtocols, linkedProtocols, defillamaId, disabled, displayName, module, category, methodologyURL, methodology, forkedFrom, audits, audit_links, versionKey, governanceID, treasury, parentProtocol, previousNames, latestFetchIsOk, slug, protocolType, total24h, total48hto24h, total7d, totalAllTime, totalDataChart, totalDataChartBreakdown, change_1d}
 
 ---
 
@@ -353,325 +840,3 @@ Get SEC filings for a company
 **Parameters:**
   - `ticker` (query, string, required) — Stock ticker symbol (case-insensitive) Example: `COIN`
 Returns: array of {filingDate, reportDate, form, primaryDocumentUrl, documentDescription}
-
----
-
-## Oracles (Beta)
-
-### GET /api/v2/metrics/oracle
-**Base URL:** `https://pro-api.llama.fi`
-Get oracle data overview. Returns mapping of oracle names to arrays of protocol names using that oracle.
-Returns: {oracles: {OracleName: [protocol1, protocol2, ...], ...}}
-
-### GET /api/v2/chart/oracle
-**Base URL:** `https://pro-api.llama.fi`
-Get timeseries chart data for all oracles. Returns array of [timestamp, value] pairs representing total oracle TVL over time.
-Returns: array of [timestamp, value]
-
-### GET /api/v2/chart/oracle/chain-breakdown
-**Base URL:** `https://pro-api.llama.fi`
-Get timeseries chart data breakdown by chain. Returns array of objects with timestamp and TVL per chain.
-Returns: array of {timestamp, Chain1: value, Chain2: value, ...}
-
-### GET /api/v2/chart/oracle/protocol-breakdown
-**Base URL:** `https://pro-api.llama.fi`
-Get timeseries chart data breakdown by protocol/oracle. Returns array of objects with timestamp and TVL per oracle.
-Returns: array of {timestamp, Oracle1: value, Oracle2: value, ...}
-
-### GET /api/v2/chart/oracle/protocol/{protocol}
-**Base URL:** `https://pro-api.llama.fi`
-Get timeseries chart data by protocol/oracle. Returns array of [timestamp, value] pairs for a specific oracle.
-
-**Parameters:**
-  - `protocol` (path, string, required) — oracle/protocol name Example: `Chainlink`
-Returns: array of [timestamp, value]
-
-### GET /api/v2/chart/oracle/protocol/{protocol}/chain-breakdown
-**Base URL:** `https://pro-api.llama.fi`
-Get chain breakdown timeseries chart data by protocol/oracle. Returns array of objects with timestamp and TVL per chain for a specific oracle.
-
-**Parameters:**
-  - `protocol` (path, string, required) — oracle/protocol name Example: `Chainlink`
-Returns: array of {timestamp, Chain1: value, Chain2: value, ...}
-
-### GET /api/v2/chart/oracle/chain/{chain}
-**Base URL:** `https://pro-api.llama.fi`
-Get timeseries chart data by chain. Returns array of [timestamp, value] pairs for oracle TVL on a specific chain.
-
-**Parameters:**
-  - `chain` (path, string, required) — chain name Example: `Ethereum`
-Returns: array of [timestamp, value]
-
-### GET /api/v2/chart/oracle/chain/{chain}/protocol-breakdown
-**Base URL:** `https://pro-api.llama.fi`
-Get protocol breakdown timeseries chart data by chain. Returns array of objects with timestamp and TVL per oracle for a specific chain.
-
-**Parameters:**
-  - `chain` (path, string, required) — chain name Example: `Ethereum`
-Returns: array of {timestamp, Oracle1: value, Oracle2: value, ...}
-
----
-
-## Forks (Beta)
-
-### GET /api/v2/metrics/fork
-**Base URL:** `https://pro-api.llama.fi`
-Get fork data overview. Returns mapping of fork protocol names to arrays of forked protocol names.
-Returns: {ForkName: [protocol1, protocol2, ...], ...}
-
-### GET /api/v2/chart/fork/protocol-breakdown
-**Base URL:** `https://pro-api.llama.fi`
-Get timeseries chart data breakdown by protocol. Returns array of objects with timestamp and TVL per fork protocol.
-Returns: array of {timestamp, Fork1: value, Fork2: value, ...}
-
-### GET /api/v2/chart/fork/protocol/{protocol}
-**Base URL:** `https://pro-api.llama.fi`
-Get timeseries chart data by protocol. Returns array of [timestamp, value] pairs for all forks of a specific protocol.
-
-**Parameters:**
-  - `protocol` (path, string, required) — protocol slug Example: `aave-v3`
-Returns: array of [timestamp, value]
-
----
-
-## Dimensions (Beta)
-
-Unified dimension endpoints for fees, DEX volumes, derivatives, options, aggregators, bridge aggregators, open interest, and normalized volume.
-
-**`{metric}` values:** fees, dexs, derivatives, options, aggregators, bridge-aggregators, open-interest, normalized-volume
-
-**`dataType` query parameter** (optional, metric-specific):
-- **fees**: dailyFees (default), dailyRevenue, dailySupplySideRevenue, dailyHoldersRevenue, dailyProtocolRevenue
-- **dexs**: dailyVolume (default), dailyNotionalVolume
-- **derivatives**: dailyVolume (default), dailyNotionalVolume
-- **options**: dailyNotionalVolume (default), dailyPremiumVolume
-- **aggregators**: dailyVolume (default)
-- **bridge-aggregators**: dailyBridgeVolume (default)
-- **open-interest**: openInterestAtEnd (default), shortOpenInterestAtEnd, longOpenInterestAtEnd
-- **normalized-volume**: dailyNormalizedVolume (default), dailyActiveLiquidity
-
-**`{protocol}`** should be slug-formatted (e.g. `aave`, `hyperliquid-perps`, `openocean`, `li.fi-bridge-aggregator`)
-**`{category}`** should be slug-formatted (e.g. `dexs`, `prediction-market`, `options`, `dex-aggregator`, `bridge-aggregator`)
-
-### Overview
-
-#### GET /api/v2/metrics/{metric}
-**Base URL:** `https://pro-api.llama.fi`
-Get dimension data overview. Returns aggregate metrics including totals and percentage changes.
-
-**Parameters:**
-  - `metric` (path, string, required) — dimension metric type Example: `fees`
-  - `dataType` (query, string, optional) — metric-specific data type
-Returns: {allChains, total24h, total48hto24h, total7d, total14dto7d, total60dto30d, total30d, total1y, change_1d, change_7d, change_1m, change_7dover7d, change_30dover30d}
-
-#### GET /api/v2/chart/{metric}
-**Base URL:** `https://pro-api.llama.fi`
-Get historical timeseries chart data.
-
-**Parameters:**
-  - `metric` (path, string, required) — dimension metric type Example: `fees`
-  - `dataType` (query, string, optional) — metric-specific data type
-Returns: array of [timestamp, value]
-
-#### GET /api/v2/chart/{metric}/chain-breakdown
-**Base URL:** `https://pro-api.llama.fi`
-Get historical timeseries chart data breakdown by chain.
-
-**Parameters:**
-  - `metric` (path, string, required) — dimension metric type Example: `fees`
-  - `dataType` (query, string, optional) — metric-specific data type
-Returns: array of [timestamp, {Chain1: value, Chain2: value, ...}]
-
-#### GET /api/v2/chart/{metric}/protocol-breakdown
-**Base URL:** `https://pro-api.llama.fi`
-Get historical timeseries chart data breakdown by protocol.
-
-**Parameters:**
-  - `metric` (path, string, required) — dimension metric type Example: `fees`
-  - `dataType` (query, string, optional) — metric-specific data type
-Returns: array of [timestamp, {Protocol1: value, Protocol2: value, ...}]
-
-### For chains
-
-#### GET /api/v2/metrics/{metric}/chain/{chain}
-**Base URL:** `https://pro-api.llama.fi`
-Get chain dimension data overview.
-
-**Parameters:**
-  - `metric` (path, string, required) — dimension metric type Example: `fees`
-  - `chain` (path, string, required) — chain name Example: `Ethereum`
-  - `dataType` (query, string, optional) — metric-specific data type
-Returns: {chain, allChains, total24h, total48hto24h, total7d, total14dto7d, total60dto30d, total30d, total1y, change_1d, change_7d, change_1m, change_7dover7d, change_30dover30d}
-
-#### GET /api/v2/chart/{metric}/chain/{chain}
-**Base URL:** `https://pro-api.llama.fi`
-Get chain historical timeseries chart data.
-
-**Parameters:**
-  - `metric` (path, string, required) — dimension metric type Example: `fees`
-  - `chain` (path, string, required) — chain name Example: `Ethereum`
-  - `dataType` (query, string, optional) — metric-specific data type
-Returns: array of [timestamp, value]
-
-#### GET /api/v2/chart/{metric}/chain/{chain}/protocol-breakdown
-**Base URL:** `https://pro-api.llama.fi`
-Get chain timeseries chart data breakdown by protocol.
-
-**Parameters:**
-  - `metric` (path, string, required) — dimension metric type Example: `fees`
-  - `chain` (path, string, required) — chain name Example: `Ethereum`
-  - `dataType` (query, string, optional) — metric-specific data type
-Returns: array of [timestamp, {Protocol1: value, Protocol2: value, ...}]
-
-### For protocols
-
-#### GET /api/v2/metrics/{metric}/protocol/{protocol}
-**Base URL:** `https://pro-api.llama.fi`
-Get protocol dimension data overview. Returns protocol metadata along with aggregate metrics.
-
-**Parameters:**
-  - `metric` (path, string, required) — dimension metric type Example: `fees`
-  - `protocol` (path, string, required) — protocol slug Example: `aave`
-  - `dataType` (query, string, optional) — metric-specific data type
-Returns: {id, name, url, description, logo, chains, gecko_id, cmcId, symbol, total24h, total48hto24h, total7d, total30d, total1y, change_1d, change_7d, change_1m}
-
-#### GET /api/v2/chart/{metric}/protocol/{protocol}
-**Base URL:** `https://pro-api.llama.fi`
-Get protocol historical timeseries chart data.
-
-**Parameters:**
-  - `metric` (path, string, required) — dimension metric type Example: `fees`
-  - `protocol` (path, string, required) — protocol slug Example: `aave`
-  - `dataType` (query, string, optional) — metric-specific data type
-Returns: array of [timestamp, value]
-
-#### GET /api/v2/chart/{metric}/protocol/{protocol}/chain-breakdown
-**Base URL:** `https://pro-api.llama.fi`
-Get protocol timeseries chart data breakdown by chain.
-
-**Parameters:**
-  - `metric` (path, string, required) — dimension metric type Example: `fees`
-  - `protocol` (path, string, required) — protocol slug Example: `aave`
-  - `dataType` (query, string, optional) — metric-specific data type
-Returns: array of [timestamp, {Chain1: value, Chain2: value, ...}]
-
-#### GET /api/v2/chart/{metric}/protocol/{protocol}/version-breakdown
-**Base URL:** `https://pro-api.llama.fi`
-Get protocol timeseries chart data breakdown by version (e.g. Aave V2, Aave V3).
-
-**Parameters:**
-  - `metric` (path, string, required) — dimension metric type Example: `fees`
-  - `protocol` (path, string, required) — protocol slug Example: `aave`
-  - `dataType` (query, string, optional) — metric-specific data type
-Returns: array of [timestamp, {Version1: value, Version2: value, ...}]
-
-#### GET /api/v2/chart/{metric}/protocol/{protocol}/label-breakdown
-**Base URL:** `https://pro-api.llama.fi`
-Get protocol timeseries chart data breakdown by label (e.g. Borrow Interest, Flash Loans). Currently only supported for metric=fees.
-
-**Parameters:**
-  - `metric` (path, string, required) — must be `fees` Example: `fees`
-  - `protocol` (path, string, required) — protocol slug Example: `aave`
-  - `dataType` (query, string, optional) — metric-specific data type
-Returns: array of [timestamp, {Label1: value, Label2: value, ...}]
-
-### For categories
-
-#### GET /api/v2/metrics/{metric}/category/{category}
-**Base URL:** `https://pro-api.llama.fi`
-Get category dimension data overview.
-
-**Parameters:**
-  - `metric` (path, string, required) — dimension metric type Example: `fees`
-  - `category` (path, string, required) — category slug Example: `dexs`
-  - `dataType` (query, string, optional) — metric-specific data type
-Returns: {category, allCategories, allChains, total24h, total48hto24h, total7d, total14dto7d, total60dto30d, total30d, total1y, change_1d, change_7d, change_1m, change_7dover7d, change_30dover30d}
-
-#### GET /api/v2/chart/{metric}/category/{category}
-**Base URL:** `https://pro-api.llama.fi`
-Get category historical timeseries chart data.
-
-**Parameters:**
-  - `metric` (path, string, required) — dimension metric type Example: `fees`
-  - `category` (path, string, required) — category slug Example: `dexs`
-  - `dataType` (query, string, optional) — metric-specific data type
-Returns: array of [timestamp, value]
-
-#### GET /api/v2/chart/{metric}/category/{category}/chain-breakdown
-**Base URL:** `https://pro-api.llama.fi`
-Get category timeseries chart data breakdown by chain.
-
-**Parameters:**
-  - `metric` (path, string, required) — dimension metric type Example: `fees`
-  - `category` (path, string, required) — category slug Example: `dexs`
-  - `dataType` (query, string, optional) — metric-specific data type
-Returns: array of [timestamp, {Chain1: value, Chain2: value, ...}]
-
-#### GET /api/v2/chart/{metric}/category/{category}/protocol-breakdown
-**Base URL:** `https://pro-api.llama.fi`
-Get category timeseries chart data breakdown by protocol.
-
-**Parameters:**
-  - `metric` (path, string, required) — dimension metric type Example: `fees`
-  - `category` (path, string, required) — category slug Example: `dexs`
-  - `dataType` (query, string, optional) — metric-specific data type
-Returns: array of [timestamp, {Protocol1: value, Protocol2: value, ...}]
-
-### For categories and chains
-
-#### GET /api/v2/metrics/{metric}/category/{category}/chain/{chain}
-**Base URL:** `https://pro-api.llama.fi`
-Get category chain dimension data overview.
-
-**Parameters:**
-  - `metric` (path, string, required) — dimension metric type Example: `fees`
-  - `category` (path, string, required) — category slug Example: `dexs`
-  - `chain` (path, string, required) — chain name Example: `Ethereum`
-  - `dataType` (query, string, optional) — metric-specific data type
-Returns: {category, chain, allCategories, allChains, total24h, total48hto24h, total7d, total14dto7d, total60dto30d, total30d, total1y, change_1d, change_7d, change_1m, change_7dover7d}
-
-#### GET /api/v2/chart/{metric}/category/{category}/chain/{chain}
-**Base URL:** `https://pro-api.llama.fi`
-Get category chain historical timeseries chart data.
-
-**Parameters:**
-  - `metric` (path, string, required) — dimension metric type Example: `fees`
-  - `category` (path, string, required) — category slug Example: `dexs`
-  - `chain` (path, string, required) — chain name Example: `Ethereum`
-  - `dataType` (query, string, optional) — metric-specific data type
-Returns: array of [timestamp, value]
-
-#### GET /api/v2/chart/{metric}/category/{category}/chain/{chain}/protocol-breakdown
-**Base URL:** `https://pro-api.llama.fi`
-Get category chain timeseries chart data breakdown by protocol.
-
-**Parameters:**
-  - `metric` (path, string, required) — dimension metric type Example: `fees`
-  - `category` (path, string, required) — category slug Example: `dexs`
-  - `chain` (path, string, required) — chain name Example: `Ethereum`
-  - `dataType` (query, string, optional) — metric-specific data type
-Returns: array of [timestamp, {Protocol1: value, Protocol2: value, ...}]
-
----
-
-## Financial Statements (Beta)
-
-### GET /api/v2/metrics/financial-statement/protocol/{protocol}
-**Base URL:** `https://pro-api.llama.fi`
-Get protocol income statement report. Returns protocol metadata, methodology details, and aggregated financial data (yearly, quarterly, monthly).
-
-When querying a **parent protocol** (e.g. `aave`), the response includes `childProtocols` with per-version methodology. When querying a **child protocol** (e.g. `aave-v3`), `methodology` and `breakdownMethodology` are at the top level.
-
-Each time period contains line items such as:
-- **Gross Protocol Revenue** — total fees collected (with label breakdown e.g. Borrow Interest, Liquidation Fees, Flashloan Fees)
-- **Cost Of Revenue** — fees distributed to suppliers/LPs
-- **Gross Profit** — revenue minus cost of revenue
-- **Token Holder Net Income** — value accruing to token holders (e.g. buybacks)
-- **Incentives** — token incentives distributed (e.g. staking rewards, lending rewards)
-- **Earnings** — net earnings after incentives
-
-Each line item has a `value` (total USD) and optional `by-label` object breaking down by revenue source.
-
-**Parameters:**
-  - `protocol` (path, string, required) — protocol slug Example: `aave-v3`
-Returns: {id, name, address, symbol, url, description, chain?, logo, audits?, audit_links?, category?, chains, oraclesBreakdown?, module?, twitter, github?, listedAt?, parentProtocol?, dimensions?, methodology?, breakdownMethodology?, methodologyURL?, tvlCodePath?, hallmarks?, linkedProtocols, childProtocols?, hasLabelBreakdown, defillamaId, displayName, slug, protocolType, aggregates: {yearly: {period: {LineItem: {value, by-label?}}}, quarterly: {...}, monthly: {...}}}

--- a/llms.txt
+++ b/llms.txt
@@ -11,7 +11,7 @@ The Free API and Pro API are entirely separate services.
 | Base URL | https://api.llama.fi | https://pro-api.llama.fi/{KEY} |
 | Auth Required | No | Yes ($300/mo) |
 | Rate Limit | Standard | Higher |
-| Endpoints | 31 | 38 exclusive + 31 free with prefix |
+| Endpoints | 31 | 77 exclusive + 31 free with prefix |
 
 Pro API authentication: insert your API key between the base URL and endpoint path:
 ```
@@ -85,15 +85,20 @@ Full documentation: [llms-pro.txt](/llms-pro.txt)
 
 Requires API key. Base URL: `https://pro-api.llama.fi`
 
-- **TVL**: `/api/tokenProtocols/{symbol}`, `/api/inflows/{protocol}/{timestamp}`, `/api/chainAssets`
-- **Stablecoins**: `/stablecoins/stablecoindominance/{chain}`
+- **TVL**: `/api/tokenProtocols/{symbol}`, `/api/inflows/{protocol}/{timestamp}`, `/api/chainAssets`, `/api/v2/metrics/tvl/protocol/{protocol}`, `/api/v2/chart/tvl/protocol/{protocol}`, `/api/v2/chart/tvl/protocol/{protocol}/chain-breakdown`, `/api/v2/chart/tvl/protocol/{protocol}/token-breakdown`
 - **Token Unlocks**: `/api/emissions`, `/api/emission/{protocol}`
 - **Protocol Analytics**: `/api/categories`, `/api/forks`, `/api/oracles`, `/api/hacks`, `/api/raises`, `/api/treasuries`, `/api/entities`
 - **Token Liquidity**: `/api/historicalLiquidity/{token}`
+- **Perpetuals & Open Interest**: `/api/overview/derivatives`, `/api/summary/derivatives/{protocol}`
+- **Treasury**: `/api/v2/metrics/treasury/protocol/{protocol}`, `/api/v2/chart/treasury/protocol/{protocol}`, `/api/v2/chart/treasury/protocol/{protocol}/chain-breakdown`, `/api/v2/chart/treasury/protocol/{protocol}/token-breakdown`
+- **Oracles**: `/api/v2/metrics/oracle`, `/api/v2/chart/oracle`, `/api/v2/chart/oracle/chain-breakdown`, `/api/v2/chart/oracle/protocol-breakdown`, `/api/v2/chart/oracle/protocol/{protocol}`, `/api/v2/chart/oracle/protocol/{protocol}/chain-breakdown`, `/api/v2/chart/oracle/chain/{chain}`, `/api/v2/chart/oracle/chain/{chain}/protocol-breakdown`
+- **Forks**: `/api/v2/metrics/fork`, `/api/v2/chart/fork/protocol-breakdown`, `/api/v2/chart/fork/protocol/{protocol}`
+- **Dimensions**: `/api/v2/metrics/{metric}`, `/api/v2/chart/{metric}`, `/api/v2/chart/{metric}/chain-breakdown`, `/api/v2/chart/{metric}/protocol-breakdown`, `/api/v2/metrics/{metric}/chain/{chain}`, `/api/v2/chart/{metric}/chain/{chain}`, `/api/v2/chart/{metric}/chain/{chain}/protocol-breakdown`, `/api/v2/metrics/{metric}/protocol/{protocol}`, `/api/v2/chart/{metric}/protocol/{protocol}`, `/api/v2/chart/{metric}/protocol/{protocol}/chain-breakdown`, `/api/v2/chart/{metric}/protocol/{protocol}/version-breakdown`, `/api/v2/chart/{metric}/protocol/{protocol}/label-breakdown`, `/api/v2/metrics/{metric}/category/{category}`, `/api/v2/chart/{metric}/category/{category}`, `/api/v2/chart/{metric}/category/{category}/chain-breakdown`, `/api/v2/chart/{metric}/category/{category}/protocol-breakdown`, `/api/v2/metrics/{metric}/category/{category}/chain/{chain}`, `/api/v2/chart/{metric}/category/{category}/chain/{chain}`, `/api/v2/chart/{metric}/category/{category}/chain/{chain}/protocol-breakdown`
+- **Financial Statements**: `/api/v2/metrics/financial-statement/protocol/{protocol}`
+- **Stablecoins**: `/stablecoins/stablecoindominance/{chain}`
 - **Yields & APY**: `/yields/poolsOld`, `/yields/poolsBorrow`, `/yields/chartLendBorrow/{pool}`, `/yields/perps`, `/yields/lsdRates`
 - **ETFs**: `/etfs/snapshot`, `/etfs/flows`
 - **Narratives**: `/fdv/performance/{period}`
-- **Perpetuals & Open Interest**: `/api/overview/derivatives`, `/api/summary/derivatives/{protocol}`
 - **Bridges**: `/bridges/bridges`, `/bridges/bridge/{id}`, `/bridges/bridgevolume/{chain}`, `/bridges/bridgedaystats/{timestamp}/{chain}`, `/bridges/transactions/{id}`
 - **API Key Management**: `/usage/APIKEY`
 - **Digital Asset Treasury**: `/dat/institutions`, `/dat/institutions/{symbol}`
@@ -101,5 +106,6 @@ Requires API key. Base URL: `https://pro-api.llama.fi`
 
 ## Optional
 
-- [OpenAPI spec (free)](/defillama-openapi-free.json): Full OpenAPI 3.0 specification for free endpoints
-- [OpenAPI spec (pro)](/defillama-openapi-pro.json): Full OpenAPI 3.0 specification for pro endpoints
+- [OpenAPI spec (free)](https://raw.githubusercontent.com/DefiLlama/api-docs/0bf9c31cf2d4fa2129fb69b377737fa60540eeeb/defillama-openapi-free.json): Full OpenAPI 3.0 specification for free endpoints
+- [OpenAPI spec (pro)](https://raw.githubusercontent.com/DefiLlama/api-docs/0bf9c31cf2d4fa2129fb69b377737fa60540eeeb/defillama-openapi-pro.json): Full OpenAPI 3.0 specification for pro endpoints
+

--- a/scripts/generate-llms.ts
+++ b/scripts/generate-llms.ts
@@ -190,7 +190,7 @@ ${mappingTable}
 
 ## Free API Endpoints (api.llama.fi)
 
-Full documentation: [llms-free.txt](/llms-free.txt)
+Full documentation: [llms-free.txt](https://raw.githubusercontent.com/DefiLlama/api-docs/0bf9c31cf2d4fa2129fb69b377737fa60540eeeb/llms-free.txt)
 
 No authentication required. Base URL: \`https://api.llama.fi\`
 
@@ -200,7 +200,7 @@ ${Array.from(freeGroups.entries())
 
 ## Pro-Only API Endpoints (pro-api.llama.fi)
 
-Full documentation: [llms-pro.txt](/llms-pro.txt)
+Full documentation: [llms-pro.txt](https://raw.githubusercontent.com/DefiLlama/api-docs/0bf9c31cf2d4fa2129fb69b377737fa60540eeeb/llms-pro.txt)
 
 Requires API key. Base URL: \`https://pro-api.llama.fi\`
 
@@ -210,8 +210,9 @@ ${Array.from(proGroups.entries())
 
 ## Optional
 
-- [OpenAPI spec (free)](/defillama-openapi-free.json): Full OpenAPI 3.0 specification for free endpoints
-- [OpenAPI spec (pro)](/defillama-openapi-pro.json): Full OpenAPI 3.0 specification for pro endpoints
+- [OpenAPI spec (free)](https://raw.githubusercontent.com/DefiLlama/api-docs/0bf9c31cf2d4fa2129fb69b377737fa60540eeeb/defillama-openapi-free.json): Full OpenAPI 3.0 specification for free endpoints
+- [OpenAPI spec (pro)](https://raw.githubusercontent.com/DefiLlama/api-docs/0bf9c31cf2d4fa2129fb69b377737fa60540eeeb/defillama-openapi-pro.json): Full OpenAPI 3.0 specification for pro endpoints
+
 `
 }
 


### PR DESCRIPTION
**Problem**
Open Api specs urls on the llms.txt file are not pointing to the actual resources, these specs tend to be very useful both for humans and llms.

Note: after running the `scripts/generate-llms.ts` script, other lines were added too, I'm not sure if they were intentionally excluded or if the script just wasn't ran for a while
**Solution**

This PR updates the `scripts/generate-llms.ts` to include full urls to GitHub

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [x] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
